### PR TITLE
Add car insurance lookup with validation and tests

### DIFF
--- a/TpInsuranceAPI.Tests/CarInsuranceEndpointTests.cs
+++ b/TpInsuranceAPI.Tests/CarInsuranceEndpointTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TpInsuranceAPI.Models;
+using TpInsuranceAPI.Providers;
+using Xunit;
+
+namespace TpInsuranceAPI.Tests;
+
+public class CarInsuranceEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public CarInsuranceEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        // Test-specific data lives here to decouple tests from production data
+        var data = new Dictionary<string, CarInsurance>
+        {
+            ["TST123"] = new("TST123", 40m)
+        };
+
+        var configuredFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<ICarInsuranceProvider>();
+                services.AddSingleton<ICarInsuranceProvider>(new TestCarInsuranceProvider(data));
+            });
+        });
+
+        _client = configuredFactory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Known_car_returns_insurance()
+    {
+        var response = await _client.PostAsJsonAsync("/car-insurance", new CarInsuranceRequest("TST123"));
+        var insurance = await response.Content.ReadFromJsonAsync<CarInsuranceResponse>();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(insurance);
+        Assert.Equal("TST123", insurance!.RegistrationNumber);
+    }
+
+    [Fact]
+    public async Task Unknown_car_returns_not_found()
+    {
+        var response = await _client.PostAsJsonAsync("/car-insurance", new CarInsuranceRequest("ZZZ999"));
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invalid_plate_returns_bad_request()
+    {
+        var response = await _client.PostAsJsonAsync("/car-insurance", new CarInsuranceRequest("BADPLATE"));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/TpInsuranceAPI.Tests/TestCarInsuranceProvider.cs
+++ b/TpInsuranceAPI.Tests/TestCarInsuranceProvider.cs
@@ -1,0 +1,24 @@
+using TpInsuranceAPI.Models;
+using TpInsuranceAPI.Providers;
+
+namespace TpInsuranceAPI.Tests;
+
+/// <summary>
+/// Minimal provider used for tests so data lives in the test project.
+/// </summary>
+public class TestCarInsuranceProvider : ICarInsuranceProvider
+{
+    private readonly Dictionary<string, CarInsurance> _data;
+
+    public TestCarInsuranceProvider(Dictionary<string, CarInsurance> data)
+    {
+        _data = data;
+    }
+
+    public Task<CarInsurance?> GetAsync(string registrationNumber)
+    {
+        _data.TryGetValue(registrationNumber.ToUpperInvariant(), out var insurance);
+        return Task.FromResult(insurance);
+    }
+}
+

--- a/TpInsuranceAPI.Tests/TpInsuranceAPI.Tests.csproj
+++ b/TpInsuranceAPI.Tests/TpInsuranceAPI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/TpInsuranceAPI.Tests/TpInsuranceAPI.Tests.csproj
+++ b/TpInsuranceAPI.Tests/TpInsuranceAPI.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/TpInsuranceAPI/Controllers/CarInsuranceController.cs
+++ b/TpInsuranceAPI/Controllers/CarInsuranceController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using TpInsuranceAPI.Models;
+using TpInsuranceAPI.Providers;
+
+namespace TpInsuranceAPI.Controllers;
+
+/// <summary>
+/// Exposes car insurance information for a given registration number.
+/// </summary>
+[ApiController]
+[Route("car-insurance")]
+public class CarInsuranceController : ControllerBase
+{
+    private readonly ICarInsuranceProvider _provider;
+
+    public CarInsuranceController(ICarInsuranceProvider provider) => _provider = provider;
+
+    [HttpPost]
+    public async Task<ActionResult<CarInsuranceResponse>> GetInsurance(CarInsuranceRequest request)
+    {
+        var insurance = await _provider.GetAsync(request.RegistrationNumber);
+        if (insurance is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(new CarInsuranceResponse(insurance.RegistrationNumber, insurance.MonthlyCost));
+    }
+}

--- a/TpInsuranceAPI/Models/CarInsurance.cs
+++ b/TpInsuranceAPI/Models/CarInsurance.cs
@@ -1,0 +1,6 @@
+namespace TpInsuranceAPI.Models;
+
+/// <summary>
+/// Basic car insurance information returned to callers.
+/// </summary>
+public record CarInsurance(string RegistrationNumber, decimal MonthlyCost);

--- a/TpInsuranceAPI/Models/CarInsuranceRequest.cs
+++ b/TpInsuranceAPI/Models/CarInsuranceRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TpInsuranceAPI.Models;
+
+/// <summary>
+/// Request body for looking up car insurance by registration number.
+/// </summary>
+public record CarInsuranceRequest(
+    [Required]
+    [RegularExpression("^[A-HJ-PR-UW-Z]{3}[0-9]{2}[0-9A-HJ-PR-UW-Z]$",
+        ErrorMessage = "Registration number must follow Swedish format")]
+    string RegistrationNumber);

--- a/TpInsuranceAPI/Models/CarInsuranceResponse.cs
+++ b/TpInsuranceAPI/Models/CarInsuranceResponse.cs
@@ -1,0 +1,6 @@
+namespace TpInsuranceAPI.Models;
+
+/// <summary>
+/// Response returned from the car insurance lookup.
+/// </summary>
+public record CarInsuranceResponse(string RegistrationNumber, decimal MonthlyCost);

--- a/TpInsuranceAPI/Program.cs
+++ b/TpInsuranceAPI/Program.cs
@@ -1,13 +1,14 @@
+using TpInsuranceAPI.Providers;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<ICarInsuranceProvider, HardcodedCarInsuranceProvider>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -16,30 +17,8 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
-    .WithName("GetWeatherForecast")
-    .WithOpenApi();
+app.MapControllers();
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
 public partial class Program { }

--- a/TpInsuranceAPI/Providers/HardcodedCarInsuranceProvider.cs
+++ b/TpInsuranceAPI/Providers/HardcodedCarInsuranceProvider.cs
@@ -1,0 +1,21 @@
+using TpInsuranceAPI.Models;
+
+namespace TpInsuranceAPI.Providers;
+
+/// <summary>
+/// Simple in-memory provider with hardcoded insurance data.
+/// </summary>
+public class HardcodedCarInsuranceProvider : ICarInsuranceProvider
+{
+    private static readonly Dictionary<string, CarInsurance> _insurances = new()
+    {
+        ["ABC123"] = new("ABC123", 30m),
+        ["DEF456"] = new("DEF456", 30m)
+    };
+
+    public Task<CarInsurance?> GetAsync(string registrationNumber)
+    {
+        _insurances.TryGetValue(registrationNumber.ToUpperInvariant(), out var insurance);
+        return Task.FromResult(insurance);
+    }
+}

--- a/TpInsuranceAPI/Providers/ICarInsuranceProvider.cs
+++ b/TpInsuranceAPI/Providers/ICarInsuranceProvider.cs
@@ -1,0 +1,11 @@
+using TpInsuranceAPI.Models;
+
+namespace TpInsuranceAPI.Providers;
+
+/// <summary>
+/// Abstraction for fetching car insurance data.
+/// </summary>
+public interface ICarInsuranceProvider
+{
+    Task<CarInsurance?> GetAsync(string registrationNumber);
+}

--- a/TpInsuranceAPI/TpInsuranceAPI.csproj
+++ b/TpInsuranceAPI/TpInsuranceAPI.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.2.24128.4"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
 </Project>

--- a/TpInsuranceAPI/TpInsuranceAPI.csproj
+++ b/TpInsuranceAPI/TpInsuranceAPI.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add hardcoded car insurance provider behind an interface and register it for DI
- expose POST `/car-insurance` endpoint with Swedish plate validation
- cover car insurance scenarios with integration tests
- use test-specific car insurance provider in tests to localize test data

## Testing
- `dotnet test TpInsuranceAPI.Tests/TpInsuranceAPI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ee9683f1883288e7e3c1699bdf89f