### PR TITLE
Improve validation and resilience

### DIFF
--- a/TpInsuranceAPI.Tests/TestInsuranceDataProvider.cs
+++ b/TpInsuranceAPI.Tests/TestInsuranceDataProvider.cs
@@ -11,6 +11,15 @@ public sealed class TestInsuranceDataProvider : IInsuranceDataProvider
         [
             new Insurance(InsuranceType.Car, "TST123"),
             new Insurance(InsuranceType.Pet, null)
+        ],
+        ["190101011235"] =
+        [
+            new Insurance(InsuranceType.Car, "MISS123")
+        ],
+        ["199901019999"] =
+        [
+            new Insurance(InsuranceType.PersonalHealth, null),
+            new Insurance(InsuranceType.PersonalHealth, null)
         ]
     };
 

--- a/TpInsuranceAPI/TpInsuranceAPI.csproj
+++ b/TpInsuranceAPI/TpInsuranceAPI.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/TpVehicleAPI.Tests/VehicleEndpointTests.cs
+++ b/TpVehicleAPI.Tests/VehicleEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -37,6 +38,8 @@ public class VehicleEndpointTests : IClassFixture<WebApplicationFactory<Program>
     {
         var response = await _client.GetAsync("/vehicles/NOPE999");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal("Vehicle NOPE999 not found", problem!.Title);
     }
 
     [Fact]
@@ -44,5 +47,7 @@ public class VehicleEndpointTests : IClassFixture<WebApplicationFactory<Program>
     {
         var response = await _client.GetAsync("/vehicles/A");
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        Assert.Contains("RegistrationNumber", problem!.Errors.Keys);
     }
 }


### PR DESCRIPTION
## Summary
- return detailed validation errors and not-found problem details from vehicle endpoint
- add Polly retry policy and robust validation with clear problem responses in insurance endpoint
- expand tests for missing data, multiple personal health policies, and vehicle lookup failures

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f7144b73483288a8ed29d5a924483