### PR TITLE
Refactor APIs with validation and v1 routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository contains a coding assignment for building an integration layer b
 - Include a README that explains architecture, how to run and test locally, and thoughts on error handling, extensibility, security, and a short personal reflection.
 
 ## Coding guidelines
+- All projects must target **.NET 9.0**. Do not change the framework version.
 - Keep code pragmatic and minimal; favour readability similar to Go over heavy patterns.
 - Avoid reflection where possible.
 - Use comments to clarify code and tests when helpful, but keep them concise.

--- a/TpInsuranceAPI.Tests/InsuranceEndpointTests.cs
+++ b/TpInsuranceAPI.Tests/InsuranceEndpointTests.cs
@@ -37,7 +37,7 @@ public class InsuranceEndpointTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task ReturnsInsurancesForKnownPersonalNumber()
     {
-        var insurances = await _client.GetFromJsonAsync<InsuranceResponse[]>("/insurances/190101011234", Json);
+        var insurances = await _client.GetFromJsonAsync<InsuranceResponse[]>("/api/v1/insurances/190101011234", Json);
         Assert.NotNull(insurances);
         var car = insurances!.First(i => i.Type == InsuranceType.Car);
         Assert.NotNull(car.Vehicle);
@@ -50,7 +50,7 @@ public class InsuranceEndpointTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task ReturnsNotFoundForUnknownPersonalNumber()
     {
-        var response = await _client.GetAsync("/insurances/200001010000");
+        var response = await _client.GetAsync("/api/v1/insurances/200001010000");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal("No insurances found", problem!.Title);
@@ -59,7 +59,7 @@ public class InsuranceEndpointTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task ReturnsBadRequestForInvalidPersonalNumber()
     {
-        var response = await _client.GetAsync("/insurances/123");
+        var response = await _client.GetAsync("/api/v1/insurances/123");
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
         Assert.Contains("PersonalNumber", problem!.Errors.Keys);
@@ -68,7 +68,7 @@ public class InsuranceEndpointTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task ReturnsConflictWhenMultiplePersonalHealthInsurances()
     {
-        var response = await _client.GetAsync("/insurances/199901019999");
+        var response = await _client.GetAsync("/api/v1/insurances/199901019999");
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal("Multiple personal health insurances found", problem!.Title);
@@ -77,9 +77,34 @@ public class InsuranceEndpointTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task ReturnsNotFoundWhenVehicleMissing()
     {
-        var response = await _client.GetAsync("/insurances/190101011235");
+        var response = await _client.GetAsync("/api/v1/insurances/190101011235");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal("Vehicle MISS123 not found", problem!.Title);
+}
+
+    [Fact]
+    public async Task ReturnsServiceUnavailableWhenVehicleServiceFails()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.UseEnvironment("Testing").ConfigureServices(services =>
+            {
+                services.RemoveAll<IInsuranceDataProvider>();
+                services.AddSingleton<IInsuranceDataProvider, TestInsuranceDataProvider>();
+                services.RemoveAll<IVehicleClient>();
+                services.AddSingleton<IVehicleClient, FailingVehicleClient>();
+            }));
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/insurances/190101011234");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal("Vehicle service unavailable", problem!.Title);
+    }
+
+    private sealed class FailingVehicleClient : IVehicleClient
+    {
+        public Task<VehicleResponse?> GetVehicleAsync(string registrationNumber)
+            => throw new VehicleServiceException("fail", new Exception());
     }
 }

--- a/TpInsuranceAPI/Clients/VehicleApiClient.cs
+++ b/TpInsuranceAPI/Clients/VehicleApiClient.cs
@@ -1,0 +1,30 @@
+namespace TpInsuranceAPI;
+
+using System.Net;
+using System.Net.Http.Json;
+
+public interface IVehicleClient
+{
+    Task<VehicleResponse?> GetVehicleAsync(string registrationNumber);
+}
+
+public sealed class VehicleApiClient(HttpClient httpClient) : IVehicleClient
+{
+    public async Task<VehicleResponse?> GetVehicleAsync(string registrationNumber)
+    {
+        try
+        {
+            return await httpClient.GetFromJsonAsync<VehicleResponse>($"/api/v1/vehicles/{registrationNumber}");
+        }
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        catch (HttpRequestException e)
+        {
+            throw new VehicleServiceException("Vehicle service failure", e);
+        }
+    }
+}
+
+public sealed class VehicleServiceException(string message, Exception inner) : Exception(message, inner);

--- a/TpInsuranceAPI/Contracts/InsuranceModels.cs
+++ b/TpInsuranceAPI/Contracts/InsuranceModels.cs
@@ -1,0 +1,29 @@
+namespace TpInsuranceAPI;
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+public readonly record struct PersonRequest(
+    [FromRoute] [StringLength(12, MinimumLength = 10)] string PersonalNumber);
+
+public sealed record InsuranceResponse(InsuranceType Type, decimal MonthlyCost, VehicleResponse? Vehicle);
+
+public sealed record Insurance(InsuranceType Type, string? RegistrationNumber)
+{
+    public decimal MonthlyCost => Type switch
+    {
+        InsuranceType.Pet => 10m,
+        InsuranceType.PersonalHealth => 20m,
+        InsuranceType.Car => 30m,
+        _ => 0m
+    };
+}
+
+public sealed record VehicleResponse(string RegistrationNumber, string Manufacturer, string Model, int ModelYear);
+
+public enum InsuranceType
+{
+    Car,
+    Pet,
+    PersonalHealth
+}

--- a/TpInsuranceAPI/Data/InsuranceDataProvider.cs
+++ b/TpInsuranceAPI/Data/InsuranceDataProvider.cs
@@ -1,0 +1,28 @@
+namespace TpInsuranceAPI;
+
+public interface IInsuranceDataProvider
+{
+    Task<IEnumerable<Insurance>> GetInsurancesAsync(string personalNumber);
+}
+
+public sealed class HardcodedInsuranceDataProvider : IInsuranceDataProvider
+{
+    private static readonly Dictionary<string, Insurance[]> Data = new()
+    {
+        ["190101011234"] =
+        [
+            new Insurance(InsuranceType.Car, "ABC123"),
+            new Insurance(InsuranceType.PersonalHealth, null)
+        ],
+        ["197705055678"] =
+        [
+            new Insurance(InsuranceType.Pet, null)
+        ]
+    };
+
+    public Task<IEnumerable<Insurance>> GetInsurancesAsync(string personalNumber)
+    {
+        Data.TryGetValue(personalNumber, out var insurances);
+        return Task.FromResult(insurances?.AsEnumerable() ?? Enumerable.Empty<Insurance>());
+    }
+}

--- a/TpInsuranceAPI/Endpoints/InsuranceEndpoints.cs
+++ b/TpInsuranceAPI/Endpoints/InsuranceEndpoints.cs
@@ -1,0 +1,53 @@
+namespace TpInsuranceAPI;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using MiniValidation;
+
+public static class InsuranceEndpoints
+{
+    public static IEndpointRouteBuilder MapInsuranceEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/v1/insurances/{personalNumber}",
+                async ([AsParameters] PersonRequest request, IInsuranceDataProvider provider, IVehicleClient vehicleClient) =>
+                {
+                    if (!MiniValidator.TryValidate(request, out var errors))
+                        return Results.ValidationProblem(errors);
+
+                    var insurances = (await provider.GetInsurancesAsync(request.PersonalNumber)).ToArray();
+                    if (insurances.Length == 0)
+                        return Results.Problem(statusCode: 404, title: "No insurances found");
+
+                    if (insurances.Count(i => i.Type == InsuranceType.PersonalHealth) > 1)
+                        return Results.Problem(statusCode: 409, title: "Multiple personal health insurances found");
+
+                    var responses = new List<InsuranceResponse>();
+                    foreach (var insurance in insurances)
+                    {
+                        VehicleResponse? vehicle = null;
+                        if (!string.IsNullOrEmpty(insurance.RegistrationNumber))
+                        {
+                            try
+                            {
+                                vehicle = await vehicleClient.GetVehicleAsync(insurance.RegistrationNumber);
+                            }
+                            catch (VehicleServiceException)
+                            {
+                                return Results.Problem(statusCode: 503, title: "Vehicle service unavailable");
+                            }
+
+                            if (vehicle is null)
+                                return Results.Problem(statusCode: 404, title: $"Vehicle {insurance.RegistrationNumber} not found");
+                        }
+                        responses.Add(new InsuranceResponse(insurance.Type, insurance.MonthlyCost, vehicle));
+                    }
+
+                    return Results.Ok(responses);
+                })
+            .RequireRateLimiting("fixed")
+            .WithName("GetInsurances")
+            .WithOpenApi();
+
+        return app;
+    }
+}

--- a/TpInsuranceAPI/Program.cs
+++ b/TpInsuranceAPI/Program.cs
@@ -1,33 +1,28 @@
-using System.ComponentModel.DataAnnotations;
 using System.Net;
-using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Http.Json;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Polly;
 using Polly.Extensions.Http;
+using TpInsuranceAPI;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-// simple hardcoded services
 builder.Services.AddSingleton<IInsuranceDataProvider, HardcodedInsuranceDataProvider>();
 builder.Services.AddHttpClient<IVehicleClient, VehicleApiClient>(client =>
 {
     var baseUrl = builder.Configuration.GetValue<string>("VehicleApiBaseUrl") ?? "http://localhost:5005";
     client.BaseAddress = new Uri(baseUrl);
 })
-    .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, i => TimeSpan.FromMilliseconds(200 * i))); // basic retry logic
+    .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, i => TimeSpan.FromMilliseconds(200 * i)));
 
-// Serialize enums as strings in JSON responses
 builder.Services.ConfigureHttpJsonOptions(opts =>
     opts.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
-// Basic fixed-window rate limiter: 10 requests per second
 builder.Services.AddRateLimiter(options =>
 {
     options.AddFixedWindowLimiter("fixed", o =>
@@ -47,130 +42,8 @@ if (app.Environment.IsDevelopment() && !app.Environment.IsEnvironment("Testing")
 }
 
 app.UseRateLimiter();
-
-app.MapGet("/insurances/{personalNumber}", async ([AsParameters] PersonRequest request, IInsuranceDataProvider provider, IVehicleClient vehicleClient) =>
-    {
-        var context = new ValidationContext(request);
-        var results = new List<ValidationResult>();
-        // Minimal APIs do not trigger DataAnnotations automatically
-        if (!Validator.TryValidateObject(request, context, results, true))
-        {
-            var errors = results
-                .SelectMany(r => r.MemberNames.Select(m => (m, error: r.ErrorMessage ?? "Invalid value")))
-                .GroupBy(e => e.m)
-                .ToDictionary(g => g.Key, g => g.Select(e => e.error).ToArray());
-            return Results.ValidationProblem(errors);
-        }
-
-        var insurances = (await provider.GetInsurancesAsync(request.PersonalNumber)).ToArray();
-        if (insurances.Length == 0)
-            return Results.Problem(statusCode: 404, title: "No insurances found");
-
-        if (insurances.Count(i => i.Type == InsuranceType.PersonalHealth) > 1)
-            return Results.Problem(statusCode: 409, title: "Multiple personal health insurances found"); // a person should only have one
-
-        var responses = new List<InsuranceResponse>();
-        foreach (var insurance in insurances)
-        {
-            VehicleResponse? vehicle = null;
-            if (!string.IsNullOrEmpty(insurance.RegistrationNumber))
-            {
-                vehicle = await vehicleClient.GetVehicleAsync(insurance.RegistrationNumber);
-                // stop if a referenced vehicle is missing
-                if (vehicle is null)
-                    return Results.Problem(statusCode: 404, title: $"Vehicle {insurance.RegistrationNumber} not found");
-            }
-            responses.Add(new InsuranceResponse(insurance.Type, insurance.MonthlyCost, vehicle));
-        }
-
-        return Results.Ok(responses);
-    })
-    .RequireRateLimiting("fixed")
-    .WithName("GetInsurances")
-    .WithOpenApi();
+app.MapInsuranceEndpoints();
 
 app.Run();
-
-// Data provider abstraction
-public interface IInsuranceDataProvider
-{
-    Task<IEnumerable<Insurance>> GetInsurancesAsync(string personalNumber);
-}
-
-// Hardcoded provider for demo purposes
-public sealed class HardcodedInsuranceDataProvider : IInsuranceDataProvider
-{
-    private static readonly Dictionary<string, Insurance[]> Data = new()
-    {
-        ["190101011234"] =
-        [
-            new Insurance(InsuranceType.Car, "ABC123"),
-            new Insurance(InsuranceType.PersonalHealth, null)
-        ],
-        ["197705055678"] =
-        [
-            new Insurance(InsuranceType.Pet, null)
-        ]
-    };
-
-    public Task<IEnumerable<Insurance>> GetInsurancesAsync(string personalNumber)
-    {
-        Data.TryGetValue(personalNumber, out var insurances);
-        return Task.FromResult(insurances?.AsEnumerable() ?? Enumerable.Empty<Insurance>());
-    }
-}
-
-// Client for vehicle lookup
-public interface IVehicleClient
-{
-    Task<VehicleResponse?> GetVehicleAsync(string registrationNumber);
-}
-
-public sealed class VehicleApiClient(HttpClient httpClient) : IVehicleClient
-{
-    public async Task<VehicleResponse?> GetVehicleAsync(string registrationNumber)
-    {
-        try
-        {
-            return await httpClient.GetFromJsonAsync<VehicleResponse>($"/vehicles/{registrationNumber}");
-        }
-        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
-        {
-            return null; // missing vehicle information is allowed
-        }
-    }
-}
-
-// Request and response models
-public sealed class PersonRequest
-{
-    [FromRoute]
-    [StringLength(12, MinimumLength = 10)]
-    public required string PersonalNumber { get; init; }
-}
-
-public sealed record InsuranceResponse(InsuranceType Type, decimal MonthlyCost, VehicleResponse? Vehicle);
-
-public sealed record Insurance(InsuranceType Type, string? RegistrationNumber)
-{
-    public decimal MonthlyCost => Type switch
-    {
-        InsuranceType.Pet => 10m,
-        InsuranceType.PersonalHealth => 20m,
-        InsuranceType.Car => 30m,
-        _ => 0m
-    };
-}
-
-public sealed record VehicleResponse(string RegistrationNumber, string Manufacturer, string Model, int ModelYear);
-
-// A simple enum is sufficient; the set of supported insurances is small and bounded,
-// so polymorphism would add unnecessary complexity.
-public enum InsuranceType
-{
-    Car,
-    Pet,
-    PersonalHealth
-}
 
 public partial class Program;

--- a/TpInsuranceAPI/TpInsuranceAPI.csproj
+++ b/TpInsuranceAPI/TpInsuranceAPI.csproj
@@ -7,9 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" />
+        <PackageReference Include="MinApiLib.Validation" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/TpInsuranceAPI/TpInsuranceAPI.http
+++ b/TpInsuranceAPI/TpInsuranceAPI.http
@@ -1,6 +1,0 @@
-@TpInsuranceAPI_HostAddress = http://localhost:5046
-
-GET {{TpInsuranceAPI_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/TpVehicleAPI.Tests/VehicleEndpointTests.cs
+++ b/TpVehicleAPI.Tests/VehicleEndpointTests.cs
@@ -28,7 +28,7 @@ public class VehicleEndpointTests : IClassFixture<WebApplicationFactory<Program>
     [Fact]
     public async Task ReturnsVehicleForKnownRegistration()
     {
-        var vehicle = await _client.GetFromJsonAsync<VehicleResponse>("/vehicles/TST123");
+        var vehicle = await _client.GetFromJsonAsync<VehicleResponse>("/api/v1/vehicles/TST123");
         Assert.NotNull(vehicle);
         Assert.Equal("TST123", vehicle!.RegistrationNumber);
     }
@@ -36,7 +36,7 @@ public class VehicleEndpointTests : IClassFixture<WebApplicationFactory<Program>
     [Fact]
     public async Task ReturnsNotFoundForUnknownRegistration()
     {
-        var response = await _client.GetAsync("/vehicles/NOPE999");
+        var response = await _client.GetAsync("/api/v1/vehicles/NOPE999");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal("Vehicle NOPE999 not found", problem!.Title);
@@ -45,7 +45,7 @@ public class VehicleEndpointTests : IClassFixture<WebApplicationFactory<Program>
     [Fact]
     public async Task ReturnsBadRequestForInvalidRegistration()
     {
-        var response = await _client.GetAsync("/vehicles/A");
+        var response = await _client.GetAsync("/api/v1/vehicles/A");
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
         Assert.Contains("RegistrationNumber", problem!.Errors.Keys);

--- a/TpVehicleAPI/Contracts/VehicleRequest.cs
+++ b/TpVehicleAPI/Contracts/VehicleRequest.cs
@@ -1,0 +1,7 @@
+namespace TpVehicleAPI;
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+public readonly record struct VehicleRequest(
+    [FromRoute] [StringLength(7, MinimumLength = 2)] string RegistrationNumber);

--- a/TpVehicleAPI/Contracts/VehicleResponse.cs
+++ b/TpVehicleAPI/Contracts/VehicleResponse.cs
@@ -1,0 +1,3 @@
+namespace TpVehicleAPI;
+
+public sealed record VehicleResponse(string RegistrationNumber, string Manufacturer, string Model, int ModelYear);

--- a/TpVehicleAPI/Data/VehicleDataProvider.cs
+++ b/TpVehicleAPI/Data/VehicleDataProvider.cs
@@ -1,0 +1,23 @@
+namespace TpVehicleAPI;
+
+public interface IVehicleDataProvider
+{
+    Task<VehicleResponse?> GetVehicleAsync(string registrationNumber);
+}
+
+public sealed class HardcodedVehicleDataProvider : IVehicleDataProvider
+{
+    private static readonly VehicleResponse[] Vehicles =
+    {
+        new("ABC123", "Volvo", "V70", 2016),
+        new("DEF456", "Saab", "9-3", 2008),
+        new("GHI789", "Tesla", "Model 3", 2023)
+    };
+
+    public Task<VehicleResponse?> GetVehicleAsync(string registrationNumber)
+    {
+        var match = Vehicles.FirstOrDefault(v =>
+            string.Equals(v.RegistrationNumber, registrationNumber, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(match);
+    }
+}

--- a/TpVehicleAPI/Endpoints/VehicleEndpoints.cs
+++ b/TpVehicleAPI/Endpoints/VehicleEndpoints.cs
@@ -1,0 +1,28 @@
+namespace TpVehicleAPI;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using MiniValidation;
+
+public static class VehicleEndpoints
+{
+    public static IEndpointRouteBuilder MapVehicleEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/v1/vehicles/{registrationNumber}",
+                async ([AsParameters] VehicleRequest request, IVehicleDataProvider provider) =>
+                {
+                    if (!MiniValidator.TryValidate(request, out var errors))
+                        return Results.ValidationProblem(errors);
+
+                    var vehicle = await provider.GetVehicleAsync(request.RegistrationNumber);
+                    return vehicle is not null
+                        ? Results.Ok(vehicle)
+                        : Results.Problem(statusCode: 404, title: $"Vehicle {request.RegistrationNumber} not found");
+                })
+            .RequireRateLimiting("fixed")
+            .WithName("GetVehicle")
+            .WithOpenApi();
+
+        return app;
+    }
+}

--- a/TpVehicleAPI/Program.cs
+++ b/TpVehicleAPI/Program.cs
@@ -1,16 +1,13 @@
-using System.ComponentModel.DataAnnotations;
 using System.Threading.RateLimiting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using TpVehicleAPI;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
 builder.Services.AddSingleton<IVehicleDataProvider, HardcodedVehicleDataProvider>();
 
-// Basic fixed-window rate limiter: 10 requests per second
 builder.Services.AddRateLimiter(options =>
 {
     options.AddFixedWindowLimiter("fixed", o =>
@@ -30,62 +27,8 @@ if (app.Environment.IsDevelopment() && !app.Environment.IsEnvironment("Testing")
 }
 
 app.UseRateLimiter();
-
-app.MapGet("/vehicles/{registrationNumber}", async ([AsParameters] VehicleRequest request, IVehicleDataProvider provider) =>
-    {
-        var validationContext = new ValidationContext(request);
-        var validationResults = new List<ValidationResult>();
-        // minimal APIs don't run DataAnnotations automatically, so validate manually
-        if (!Validator.TryValidateObject(request, validationContext, validationResults, true))
-        {
-            var errors = validationResults
-                .SelectMany(r => r.MemberNames.Select(m => (m, error: r.ErrorMessage ?? "Invalid value")))
-                .GroupBy(e => e.m)
-                .ToDictionary(g => g.Key, g => g.Select(e => e.error).ToArray());
-            return Results.ValidationProblem(errors);
-        }
-
-        var plate = request.RegistrationNumber;
-        var vehicle = await provider.GetVehicleAsync(plate);
-        return vehicle is not null
-            ? Results.Json(vehicle)
-            : Results.Problem(statusCode: 404, title: $"Vehicle {plate} not found");
-    })
-    .RequireRateLimiting("fixed")
-    .WithName("GetVehicle")
-    .WithOpenApi();
+app.MapVehicleEndpoints();
 
 app.Run();
-
-public interface IVehicleDataProvider
-{
-    Task<VehicleResponse?> GetVehicleAsync(string registrationNumber);
-}
-
-public sealed class HardcodedVehicleDataProvider : IVehicleDataProvider
-{
-    private static readonly VehicleResponse[] Vehicles =
-    {
-        new("ABC123", "Volvo", "V70", 2016),
-        new("DEF456", "Saab", "9-3", 2008),
-        new("GHI789", "Tesla", "Model 3", 2023)
-    };
-
-    public Task<VehicleResponse?> GetVehicleAsync(string registrationNumber)
-    {
-        var match = Vehicles.FirstOrDefault(v =>
-            string.Equals(v.RegistrationNumber, registrationNumber, StringComparison.OrdinalIgnoreCase));
-        return Task.FromResult(match);
-    }
-}
-
-public sealed class VehicleRequest
-{
-    [FromRoute]
-    [StringLength(7, MinimumLength = 2)]
-    public required string RegistrationNumber { get; init; }
-}
-
-public sealed record VehicleResponse(string RegistrationNumber, string Manufacturer, string Model, int ModelYear);
 
 public partial class Program;

--- a/TpVehicleAPI/TpVehicleAPI.csproj
+++ b/TpVehicleAPI/TpVehicleAPI.csproj
@@ -7,8 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="MinApiLib.Validation" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/TpVehicleAPI/TpVehicleAPI.http
+++ b/TpVehicleAPI/TpVehicleAPI.http
@@ -1,6 +1,0 @@
-@TpVehicleAPI_HostAddress = http://localhost:5001
-
-GET {{TpVehicleAPI_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.304",
+    "version": "9.0.100",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
## Summary
- restructure insurance and vehicle APIs with extension-based endpoints under `/api/v1`
- handle vehicle service errors with 503 responses
- streamline input validation using MiniValidation and remove leftover .http files
- target .NET 9 across the solution and document it as a requirement

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0306873588328a8644c53b832d648